### PR TITLE
fix: does not work after moving page

### DIFF
--- a/assets/doc-search.js
+++ b/assets/doc-search.js
@@ -1,11 +1,19 @@
 require(["gitbook"], function(gitbook) {
-    gitbook.events.bind("start", function(e, config) {
-        var cfg = config.docSearch;
+    var pluginsConfig = {};
+    var initDocSearch = function() {
+        var cfg = pluginsConfig.docSearch;
         docsearch({
             apiKey: cfg.apiKey,
             indexName: cfg.index,
             inputSelector: '#book-doc-search-input',
             debug: false
         });
+    }
+    gitbook.events.bind("start", function(e, config) {
+        pluginsConfig = config;
+        initDocSearch();
+    });
+    gitbook.events.bind("page.change", function() {
+        initDocSearch();
     });
 });


### PR DESCRIPTION
I've noticed that we can not search after moving page.
Because, GitBook use [pjax](https://github.com/defunkt/jquery-pjax "pjax") approch.
It will replace all body content when moving page.

So, This PR fix this issue.

Similar implementation:

- https://github.com/GitbookIO/plugin-search/blob/d9dac61c4e7b45dc87461bfd898f601e48a23b3a/assets/search.js#L160-L175